### PR TITLE
Fixup item models

### DIFF
--- a/assets/lootbags/models/item/lootbag.json
+++ b/assets/lootbags/models/item/lootbag.json
@@ -1,19 +1,7 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/generated",
     "textures": {
         "layer0": "lootbags:items/lootbagTextureBase",
         "layer1": "lootbags:items/lootbagTextureString"
-    },
-    "display": {
-        "thirdperson": {
-            "rotation": [ -90, 0, 0 ],
-            "translation": [ 0, 1, -3 ],
-            "scale": [ 0.55, 0.55, 0.55 ]
-        },
-        "firstperson": {
-            "rotation": [ 0, -135, 25 ],
-            "translation": [ 0, 4, 2 ],
-            "scale": [ 1.7, 1.7, 1.7 ]
-        }
     }
 }

--- a/assets/lootbags/models/item/lootbagBacon.json
+++ b/assets/lootbags/models/item/lootbagBacon.json
@@ -1,18 +1,6 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/generated",
     "textures": {
         "layer0": "lootbags:items/lootbagBaconItemTexture"
-    },
-    "display": {
-        "thirdperson": {
-            "rotation": [ -90, 0, 0 ],
-            "translation": [ 0, 1, -3 ],
-            "scale": [ 0.55, 0.55, 0.55 ]
-        },
-        "firstperson": {
-            "rotation": [ 0, -135, 25 ],
-            "translation": [ 0, 4, 2 ],
-            "scale": [ 1.7, 1.7, 1.7 ]
-        }
     }
 }

--- a/assets/lootbags/models/item/lootbagBat.json
+++ b/assets/lootbags/models/item/lootbagBat.json
@@ -1,18 +1,6 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/generated",
     "textures": {
         "layer0": "lootbags:items/lootbagBatItemTexture"
-    },
-    "display": {
-        "thirdperson": {
-            "rotation": [ -90, 0, 0 ],
-            "translation": [ 0, 1, -3 ],
-            "scale": [ 0.55, 0.55, 0.55 ]
-        },
-        "firstperson": {
-            "rotation": [ 0, -135, 25 ],
-            "translation": [ 0, 4, 2 ],
-            "scale": [ 1.7, 1.7, 1.7 ]
-        }
     }
 }

--- a/assets/lootbags/models/item/lootbagCommon.json
+++ b/assets/lootbags/models/item/lootbagCommon.json
@@ -1,18 +1,6 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/generated",
     "textures": {
         "layer0": "lootbags:items/lootbagCommonItemTexture"
-    },
-    "display": {
-        "thirdperson": {
-            "rotation": [ -90, 0, 0 ],
-            "translation": [ 0, 1, -3 ],
-            "scale": [ 0.55, 0.55, 0.55 ]
-        },
-        "firstperson": {
-            "rotation": [ 0, -135, 25 ],
-            "translation": [ 0, 4, 2 ],
-            "scale": [ 1.7, 1.7, 1.7 ]
-        }
     }
 }

--- a/assets/lootbags/models/item/lootbagDarkosto.json
+++ b/assets/lootbags/models/item/lootbagDarkosto.json
@@ -1,18 +1,6 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/generated",
     "textures": {
         "layer0": "lootbags:items/lootbagDarkostoItemTexture"
-    },
-    "display": {
-        "thirdperson": {
-            "rotation": [ -90, 0, 0 ],
-            "translation": [ 0, 1, -3 ],
-            "scale": [ 0.55, 0.55, 0.55 ]
-        },
-        "firstperson": {
-            "rotation": [ 0, -135, 25 ],
-            "translation": [ 0, 4, 2 ],
-            "scale": [ 1.7, 1.7, 1.7 ]
-        }
     }
 }

--- a/assets/lootbags/models/item/lootbagEpic.json
+++ b/assets/lootbags/models/item/lootbagEpic.json
@@ -1,18 +1,6 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/generated",
     "textures": {
         "layer0": "lootbags:items/lootbagEpicItemTexture"
-    },
-    "display": {
-        "thirdperson": {
-            "rotation": [ -90, 0, 0 ],
-            "translation": [ 0, 1, -3 ],
-            "scale": [ 0.55, 0.55, 0.55 ]
-        },
-        "firstperson": {
-            "rotation": [ 0, -135, 25 ],
-            "translation": [ 0, 4, 2 ],
-            "scale": [ 1.7, 1.7, 1.7 ]
-        }
     }
 }

--- a/assets/lootbags/models/item/lootbagLegendary.json
+++ b/assets/lootbags/models/item/lootbagLegendary.json
@@ -1,18 +1,6 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/generated",
     "textures": {
         "layer0": "lootbags:items/lootbagLegendaryItemTexture"
-    },
-    "display": {
-        "thirdperson": {
-            "rotation": [ -90, 0, 0 ],
-            "translation": [ 0, 1, -3 ],
-            "scale": [ 0.55, 0.55, 0.55 ]
-        },
-        "firstperson": {
-            "rotation": [ 0, -135, 25 ],
-            "translation": [ 0, 4, 2 ],
-            "scale": [ 1.7, 1.7, 1.7 ]
-        }
     }
 }

--- a/assets/lootbags/models/item/lootbagRare.json
+++ b/assets/lootbags/models/item/lootbagRare.json
@@ -1,18 +1,6 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/generated",
     "textures": {
         "layer0": "lootbags:items/lootbagRareItemTexture"
-    },
-    "display": {
-        "thirdperson": {
-            "rotation": [ -90, 0, 0 ],
-            "translation": [ 0, 1, -3 ],
-            "scale": [ 0.55, 0.55, 0.55 ]
-        },
-        "firstperson": {
-            "rotation": [ 0, -135, 25 ],
-            "translation": [ 0, 4, 2 ],
-            "scale": [ 1.7, 1.7, 1.7 ]
-        }
     }
 }

--- a/assets/lootbags/models/item/lootbagSoaryn.json
+++ b/assets/lootbags/models/item/lootbagSoaryn.json
@@ -1,18 +1,6 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/generated",
     "textures": {
         "layer0": "lootbags:items/lootbagSoarynItemTexture"
-    },
-    "display": {
-        "thirdperson": {
-            "rotation": [ -90, 0, 0 ],
-            "translation": [ 0, 1, -3 ],
-            "scale": [ 0.55, 0.55, 0.55 ]
-        },
-        "firstperson": {
-            "rotation": [ 0, -135, 25 ],
-            "translation": [ 0, 4, 2 ],
-            "scale": [ 1.7, 1.7, 1.7 ]
-        }
     }
 }

--- a/assets/lootbags/models/item/lootbagUncommon.json
+++ b/assets/lootbags/models/item/lootbagUncommon.json
@@ -1,18 +1,6 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/generated",
     "textures": {
         "layer0": "lootbags:items/lootbagUncommonItemTexture"
-    },
-    "display": {
-        "thirdperson": {
-            "rotation": [ -90, 0, 0 ],
-            "translation": [ 0, 1, -3 ],
-            "scale": [ 0.55, 0.55, 0.55 ]
-        },
-        "firstperson": {
-            "rotation": [ 0, -135, 25 ],
-            "translation": [ 0, 4, 2 ],
-            "scale": [ 1.7, 1.7, 1.7 ]
-        }
     }
 }

--- a/assets/lootbags/models/item/lootbagWornOut.json
+++ b/assets/lootbags/models/item/lootbagWornOut.json
@@ -1,18 +1,6 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/generated",
     "textures": {
         "layer0": "lootbags:items/lootbagWornOutItemTexture"
-    },
-    "display": {
-        "thirdperson": {
-            "rotation": [ -90, 0, 0 ],
-            "translation": [ 0, 1, -3 ],
-            "scale": [ 0.55, 0.55, 0.55 ]
-        },
-        "firstperson": {
-            "rotation": [ 0, -135, 25 ],
-            "translation": [ 0, 4, 2 ],
-            "scale": [ 1.7, 1.7, 1.7 ]
-        }
     }
 }

--- a/assets/lootbags/models/item/lootbagWyld.json
+++ b/assets/lootbags/models/item/lootbagWyld.json
@@ -1,18 +1,6 @@
 {
-    "parent": "builtin/generated",
+    "parent": "item/generated",
     "textures": {
         "layer0": "lootbags:items/lootbagWyldItemTexture"
-    },
-    "display": {
-        "thirdperson": {
-            "rotation": [ -90, 0, 0 ],
-            "translation": [ 0, 1, -3 ],
-            "scale": [ 0.55, 0.55, 0.55 ]
-        },
-        "firstperson": {
-            "rotation": [ 0, -135, 25 ],
-            "translation": [ 0, 4, 2 ],
-            "scale": [ 1.7, 1.7, 1.7 ]
-        }
     }
 }


### PR DESCRIPTION
Use the `item/generated` parent instead of `builtin/generated` so that the proper vanilla transformations are automatically applied. Loot Bags now appear the same in-hand as normal vanilla items.
