### PR TITLE
Fix potential nullpointer

### DIFF
--- a/mal/lootbags/handler/BagHandler.java
+++ b/mal/lootbags/handler/BagHandler.java
@@ -118,7 +118,10 @@ public class BagHandler {
 	{
 		if(isIDFree(ID))
 			return true;
-		return bagList.get(ID).isBagEmpty();
+		Bag bag = bagList.get(ID);
+		if(bag == null)
+			return true;
+		return bag.isBagEmpty();
 	}
 	
 	public static ArrayList<Bag> getBagListRandomized()


### PR DESCRIPTION
Had a crash running Foolcraft 2.1, hopefully this fixes it :)

Here's the log:

---- Minecraft Crash Report ----
Description: Ticking block entity

java.lang.NullPointerException: Ticking block entity
        at mal.lootbags.handler.BagHandler.isBagEmpty(BagHandler.java:116)
        at mal.lootbags.item.LootbagItem.getEntityLifespan(LootbagItem.java:435)
        at net.minecraft.entity.item.EntityItem.<init>(EntityItem.java:66)
        at net.minecraft.entity.Entity.func_70099_a(Entity.java:1772)
        at net.minecraft.entity.EntityLiving.func_184610_a(EntityLiving.java:548)
        at net.minecraft.entity.EntityLivingBase.func_70645_a(EntityLivingBase.java:1080)
        at net.minecraft.entity.EntityLivingBase.func_70097_a(EntityLivingBase.java:970)
        at net.minecraft.entity.monster.EntityMob.func_70097_a(SourceFile:73)
        at net.minecraft.entity.boss.EntityWither.func_70097_a(EntityWither.java:550)
        at mcjty.rftools.blocks.shield.ShieldTEBase.applyDamageToEntity(ShieldTEBase.java:536)
        at mcjty.rftools.blocks.shield.TickShieldBlockTileEntity.handleDamage(TickShieldBlockTileEntity.java:47)
        at mcjty.rftools.blocks.shield.TickShieldBlockTileEntity.func_73660_a(TickShieldBlockTileEntity.java:22)
        at net.minecraft.world.World.func_72939_s(World.java:1804)
        at net.minecraft.world.WorldServer.func_72939_s(WorldServer.java:620)
        at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:709)
        at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:387)
        at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:613)
        at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:471)
        at java.lang.Thread.run(Thread.java:745)