### PR TITLE
Fix multiple duplication bugs and NPE

### DIFF
--- a/mal/lootbags/gui/StorageContainer.java
+++ b/mal/lootbags/gui/StorageContainer.java
@@ -54,6 +54,9 @@ public class StorageContainer extends Container{
     @Override
     @Nonnull
     public ItemStack slotClick(int slotPos, int pressedKey, @Nonnull ClickType clickTypeIn, @Nonnull EntityPlayer player) {
+        if (slotPos < 0 || slotPos >= inventorySlots.size()) {
+            return super.slotClick(slotPos, pressedKey, clickTypeIn, player);
+        }
         Slot selectedSlot = inventorySlots.get(slotPos);
         if (clickTypeIn == ClickType.SWAP && slotPos == OUTPUT_SLOT && pressedKey >= 0 && pressedKey < 9) {
             if (player.inventory.getStackInSlot(pressedKey).isEmpty() && selectedSlot.getHasStack()) {

--- a/mal/lootbags/tileentity/TileEntityStorage.java
+++ b/mal/lootbags/tileentity/TileEntityStorage.java
@@ -269,14 +269,15 @@ public class TileEntityStorage extends TileEntity implements IInventory, ISidedI
 
 	@Override
 	public ItemStack decrStackSize(int slot, int dec) {
-		if(slot == 0)
+		if(slot == 0) // Output
 		{
-			int value = BagHandler.getBagValue(outputID)[1];
-			if(stored_value >= value)
-			{
-				stored_value -= value;
-				return new ItemStack(LootBags.lootbagItem, 1, outputID);
+			int bagValue = BagHandler.getBagValue(outputID)[1];
+			int bagsToRemove = Math.min(dec, stored_value / bagValue);
+			if (bagsToRemove == 0) {
+				return ItemStack.EMPTY;
 			}
+			stored_value -= bagValue * bagsToRemove;
+			return new ItemStack(LootBags.lootbagItem, bagsToRemove, outputID);
 		}
 		else
 		{

--- a/mal/lootbags/tileentity/TileEntityStorage.java
+++ b/mal/lootbags/tileentity/TileEntityStorage.java
@@ -429,22 +429,30 @@ public class TileEntityStorage extends TileEntity implements IInventory, ISidedI
 
 	@Override
 	public boolean isUsableByPlayer(EntityPlayer player) {
-		return this.world.getTileEntity(this.pos) != this ? false : player.getDistanceSq(this.pos.getX() + 0.5D, this.pos.getY() + 0.5D, this.pos.getZ() + 0.5D) <= 64.0D;
+		if (this.world.getTileEntity(this.pos) != this) {
+			return false;
+		}
+		return player.getDistanceSq(this.pos.getX() + 0.5D, this.pos.getY() + 0.5D, this.pos.getZ() + 0.5D) <= 64.0D;
 	}
 
 	public int getID() {
 		return outputID;
 	}
 
-	public void decrStorage(ItemStack is) {
-		if(is != null && !is.isEmpty() && is.getItem() instanceof LootbagItem)
-		{
-			int value = BagHandler.getBagValue(is.getMetadata())[1];
-			if(stored_value >= value)
-				stored_value -= value;
-			else
-				stored_value = 0;
+	public void decrStorage(ItemStack itemStack) {
+		if (itemStack == null || itemStack.isEmpty() || !(itemStack.getItem() instanceof LootbagItem)) {
+			return; //TODO: err here
 		}
+		int value = BagHandler.getBagValue(itemStack.getMetadata())[1];
+		stored_value = Math.max(0, stored_value - value);
+	}
+
+	public void incrementStorage(ItemStack itemStack) {
+		if (itemStack == null || itemStack.isEmpty() || !(itemStack.getItem() instanceof LootbagItem)) {
+			return; //TODO: err here
+		}
+		int value = BagHandler.getBagValue(itemStack.getMetadata())[1];
+		stored_value += value;
 	}
 }
 /*******************************************************************************


### PR DESCRIPTION
Fix #185 where it removes 2 but only gives one lootbag when shift clicking

Fix #188 fix #178 where using the number keys gives a stack when it should only give 1.

Pretty sure it fixes  #191, although their description seems the opposite of the bug I'm seeing.

Also fixed two bugs I found myself. One where using pipes (tested with EnderIO), it will extract a larger number of bags than it removes, thus duping bags.
Second, a null pointer when interacting with the bags GUI sometimes.